### PR TITLE
Ignore extra virtual environment folders

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@
 - **Repository Info:** Display the latest commits and file change summaries.
 - **Diffing:** Compare different versions of your code using external diff tools.
 - **GitHub Integration:** Automatically create a GitHub repository, add it as a remote, and push your local branch.
-- **Exclusion of Unwanted Files:** Automatically ignores directories like `target`, `bin`, `obj`, and `venv` so that build artifacts and virtual environments do not clutter your repository.
+- **Exclusion of Unwanted Files:** Automatically ignores directories like `target`, `bin`, `obj`, `venv`, `.venv`, and `env` so that build artifacts and virtual environments do not clutter your repository.
 - **Multi-Language Support:** Recognizes various file types (Rust, Python, C/C++, Java, etc.) to accurately identify source files.
 
 ## Installation

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ Key features and structure:
 - Uses Clap for parsing command-line arguments.
 - Leverages git2 for Git repository operations (initial commit, diffing, etc.).
 - Scans directories for source files using WalkDir while filtering out build artifact directories 
-  ("target", "bin", "obj", "venv") that are commonly generated in various build and virtual environment setups.
+  ("target", "bin", "obj", "venv", ".venv", "env") that are commonly generated in various build and virtual environment setups.
 - Provides utility functions for generating a .gitignore file, detecting file types, and checking out Git trees.
 - Uses colored logging to provide clear output to the user.
 - Integrates with GitHub using octocrab for API calls.
@@ -220,13 +220,18 @@ fn main() {
     }
 }
 
-/// Returns true if any component of the entry's path is named "target", "bin", "obj", or "venv".
+/// Returns true if any component of the entry's path is an excluded directory.
+///
+/// The tool ignores common build and virtual environment folders: `target`,
+/// `bin`, `obj`, `venv`, `.venv`, and `env`.
 fn is_in_excluded_dir(entry: &walkdir::DirEntry) -> bool {
     entry.path().components().any(|comp| {
         comp.as_os_str() == "target" ||
         comp.as_os_str() == "bin" ||
         comp.as_os_str() == "obj" ||
-        comp.as_os_str() == "venv"
+        comp.as_os_str() == "venv" ||
+        comp.as_os_str() == ".venv" ||
+        comp.as_os_str() == "env"
     })
 }
 
@@ -697,8 +702,17 @@ fn create_gitignore(dir: &str, dry_run: bool) -> Result<(), Box<dyn Error>> {
 /// Generate the content for the .gitignore file.
 fn generate_gitignore_content(_dir: &str) -> Result<String, Box<dyn Error>> {
     log::debug!("Generating .gitignore content...");
-    // Added "venv/" to ignore virtual environments.
-    let ignore_patterns = vec!["target/", "bin/", "obj/", "venv/", "*.tmp", "*.log"];
+    // Ignore common build and virtual environment directories
+    let ignore_patterns = vec![
+        "target/",
+        "bin/",
+        "obj/",
+        "venv/",
+        ".venv/",
+        "env/",
+        "*.tmp",
+        "*.log",
+    ];
     Ok(ignore_patterns.join("\n"))
 }
 
@@ -904,7 +918,7 @@ mod tests {
     #[test]
     fn test_generate_gitignore_content() {
         let content = generate_gitignore_content(".").unwrap();
-        let expected = "target/\nbin/\nobj/\nvenv/\n*.tmp\n*.log";
+        let expected = "target/\nbin/\nobj/\nvenv/\n.venv/\nenv/\n*.tmp\n*.log";
         assert_eq!(content, expected);
     }
 


### PR DESCRIPTION
## Summary
- update comments to include `.venv` and `env`
- ignore `.venv` and `env` directories when scanning
- update `.gitignore` generation
- adjust README to mention the new exclusions
- fix tests for updated ignore patterns

## Testing
- `cargo test --quiet` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68580da1659c832aa0b589a70c4857fa